### PR TITLE
Initialize next queue with seven-bag

### DIFF
--- a/src/contexts/GameContext.test.tsx
+++ b/src/contexts/GameContext.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { GameProvider, useGame } from './GameContext';
+import { KeyConfigProvider } from './KeyConfigContext';
+
+vi.mock('../lib/persist', () => ({
+  initializePersistence: vi.fn(async () => ({ success: true })),
+}));
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <KeyConfigProvider>
+    <GameProvider>{children}</GameProvider>
+  </KeyConfigProvider>
+);
+
+describe('GameContext - seven bag and NEXT integration', () => {
+  it('initializes next queue and advances after starting the game', async () => {
+    const { result } = renderHook(() => useGame(), { wrapper });
+
+    // Wait for any pending effects (e.g., persistence init)
+    await act(async () => {});
+
+    const initialNext = result.current.state.gameState.nextPieces;
+    expect(initialNext).toHaveLength(5);
+
+    await act(async () => {
+      result.current.actions.startGame();
+    });
+
+    const state = result.current.state.gameState;
+    expect(state.currentPiece?.type).toBe(initialNext[0]);
+    expect(state.nextPieces.slice(0, 4)).toEqual(initialNext.slice(1));
+  });
+});

--- a/src/contexts/GameContext.tsx
+++ b/src/contexts/GameContext.tsx
@@ -45,29 +45,33 @@ type GameAction =
 
 const initialBoard = createBoard();
 
-const createInitialState = (): GameContextState => ({
-  gameState: {
-    board: initialBoard,
-    currentPiece: null,
-    heldPiece: null,
-    nextPieces: [],
-    score: 0,
-    lines: 0,
-    level: 1,
-    isGameOver: false,
-    canHold: true,
-    lockDelay: 0,
-    softDropLockReset: false,
-    wasSoftDropping: false,
-    isSoftDropping: false,
-  },
-  inputHandler: createInputHandler(),
-  bag: createBagGenerator(),
-  isPlaying: false,
-  isPersistenceReady: false,
-  currentMoveCount: 0,
-  recordedMoves: [],
-});
+const createInitialState = (): GameContextState => {
+  const bag = createBagGenerator();
+
+  return {
+    gameState: {
+      board: initialBoard,
+      currentPiece: null,
+      heldPiece: null,
+      nextPieces: bag.peek(5),
+      score: 0,
+      lines: 0,
+      level: 1,
+      isGameOver: false,
+      canHold: true,
+      lockDelay: 0,
+      softDropLockReset: false,
+      wasSoftDropping: false,
+      isSoftDropping: false,
+    },
+    inputHandler: createInputHandler(),
+    bag,
+    isPlaying: false,
+    isPersistenceReady: false,
+    currentMoveCount: 0,
+    recordedMoves: [],
+  };
+};
 
 function gameReducer(state: GameContextState, action: GameAction): GameContextState {
   switch (action.type) {


### PR DESCRIPTION
## Summary
- Seed game state with a seven-bag peek so NEXT is populated before play starts
- Add a GameContext test verifying next queue advances after starting the game

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any, no-unused-vars, and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a0713eb500832f9ca1cae637370383